### PR TITLE
Fix incorrect log4j.properties example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ but change that to whatever you specified earlier.
 Example: log4j.properties
 
 ```
-log4j.rundeck=INFO, SYSLOG
+log4j.logger.rundeck=INFO, SYSLOG
 # configure Syslog facility LOCAL1 appender
 log4j.appender.SYSLOG=org.apache.log4j.net.SyslogAppender
 log4j.appender.SYSLOG.threshold=WARN


### PR DESCRIPTION
The configuration for logger X needs to be `log4j.logger.X` rather than `log4j.X`.