### PR TITLE
Fix NPE on jobs without group names

### DIFF
--- a/src/Log4jStreamingLogWriterPlugin.groovy
+++ b/src/Log4jStreamingLogWriterPlugin.groovy
@@ -57,7 +57,9 @@ rundeckPlugin(StreamingLogWriterPlugin) {
         }
         MDC.put("username", context.execution.username)
         MDC.put("name", context.execution.name)
-        MDC.put("group", context.execution.group)
+        if (context.execution.group != null) {
+            MDC.put("group", context.execution.group)
+        }
         MDC.put("execid", context.execution.execid)
         MDC.put("project", context.execution.project)
         MDC.put("id", context.execution.id)


### PR DESCRIPTION
Group names are optional in Rundeck, but if you have a job with no group name, the plugin throws NullPointerException because it tries to add a null value to a HashMap.